### PR TITLE
fix Docker FromAsCasing warning

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage
-FROM node:16 as build
+FROM node:16 AS build
 WORKDIR /src
 COPY . ./
 


### PR DESCRIPTION
```
 1 warning found (use --debug to expand):
 - FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 2)
```